### PR TITLE
Fix weekly schedule

### DIFF
--- a/src/timely/core.clj
+++ b/src/timely/core.clj
@@ -155,7 +155,7 @@
    specified, a default day of Sunday and a default hour and minute of
    0 is used.  Filters available: at, on, each, start-time, end-time"
    [& filters]
-  (apply (partial create-schedule 0 0 :all :all 0) filters))
+  (apply (partial create-schedule 0 0 :all :all :sun) filters))
 
 (defn monthly
   "Create a schedule that runs once every month.  Optionally specify

--- a/test/timely/test/core.clj
+++ b/test/timely/test/core.clj
@@ -55,4 +55,5 @@
   (is (= "* * * * *"     (schedule-to-cron (each-minute (start-time 0) (end-time (* (dates-coerce/to-long (dates/now)) 2))))))
   (is (= "* * * * *"     (schedule-to-cron (each-minute
                                             (start-time (to-utc-timestamp (dates/date-time 2012 5 15 11 42)))
-                                            (end-time (to-utc-timestamp (dates/date-time 2012 5 15 11 43))))))))
+                                            (end-time (to-utc-timestamp (dates/date-time 2012 5 15 11 43)))))))
+  (is (= "0 0 * * 6"     (schedule-to-cron (weekly (on (day-of-week :sat)))))))


### PR DESCRIPTION
Hi, I'm getting an exception when calling `weekly`: `Not a valid day of the week: 0`. I think the problem is that `create-schedule` expects a keyword for the day of the week, but `weekly` is passing it `0` instead. Here's a fix for it, and I've also added a test to verify that it works.